### PR TITLE
fix compatibility issue to airbrake_ruby 2.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Set the `project_id` to any number, it is ignored by this plugin but validated
 by the Airbrake client. The same is true for the `project_key` string.
 
 The `root_directory` Airbrake option shortens backtrace lines by replacing your
-projects installation directory with `[PROJECT_ROOT]`
+projects installation directory with `[PROJECT_ROOT]` or (since [airbrake-ruby 2.9+](https://github.com/airbrake/airbrake-ruby/pull/311/commits/d6e3855a66a104162ba1beba3f1da559a80130bd) with `/PROJECT_ROOT/`)
 
 
 Congratulations. You can now start receiving exceptions in Redmine!

--- a/lib/redmine_airbrake/error.rb
+++ b/lib/redmine_airbrake/error.rb
@@ -34,7 +34,8 @@ module RedmineAirbrake
     # source linking)
     def line
       (filtered_backtrace || backtrace).detect do |frame|
-        frame['file'] =~ /\A\[PROJECT_ROOT\]/
+        # We match both the old format [PROJECT_ROOT] and the new style /PROJECT_ROOT/
+        frame['file'] =~ /\A(?:\[|\/)PROJECT_ROOT(?:\]|\/)/
       end
     end
 

--- a/lib/redmine_airbrake/error.rb
+++ b/lib/redmine_airbrake/error.rb
@@ -35,7 +35,7 @@ module RedmineAirbrake
     def line
       (filtered_backtrace || backtrace).detect do |frame|
         # We match both the old format [PROJECT_ROOT] and the new style /PROJECT_ROOT/
-        frame['file'] =~ /\A(?:\[|\/)PROJECT_ROOT(?:\]|\/)/
+        frame['file'] =~ /\A[\[\/]PROJECT_ROOT\]?\//
       end
     end
 

--- a/lib/redmine_airbrake/notice/base.rb
+++ b/lib/redmine_airbrake/notice/base.rb
@@ -86,8 +86,10 @@ module RedmineAirbrake
         errors.first
       end
 
+      # remove [POJECT_PATH] or [GEM_PATH] from a path
+      # works also with new format /PROJECT_PATH/ or /GEM_PATH/
       def cleanup_path(path)
-        path.sub(/\A\[[A-Z]+_ROOT\]\//, '')
+        path.sub(/\A(?:\[|\/)[A-Z]+_ROOT]?\//, '')
       end
 
       # issue subject

--- a/lib/redmine_airbrake/notice/base.rb
+++ b/lib/redmine_airbrake/notice/base.rb
@@ -89,7 +89,7 @@ module RedmineAirbrake
       # remove [POJECT_PATH] or [GEM_PATH] from a path
       # works also with new format /PROJECT_PATH/ or /GEM_PATH/
       def cleanup_path(path)
-        path.sub(/\A(?:\[|\/)[A-Z]+_ROOT]?\//, '')
+        path.sub(/\A[\[\/][A-Z]+_ROOT\]?\//, '')
       end
 
       # issue subject


### PR DESCRIPTION
add detection and cleanup for `/PROJECT_ROOT/`

refs #3